### PR TITLE
fix demo 404

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,6 @@ jobs:
           fvm config --cache-path ../.fvm/cache
           fvm flutter pub get
           fvm flutter build web --release --web-renderer auto --base-href "/flutter_seo/"
-          cp build/web/index.html build/web/404.html
       - name: upload artifact
         uses: actions/upload-pages-artifact@v1
         with:

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,10 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_web_plugins/url_strategy.dart';
 import 'package:seo/seo.dart';
 import 'package:seo_example/main_router.dart';
 
 void main() {
-  usePathUrlStrategy();
   runApp(App());
 }
 

--- a/example/lib/widgets/app_link.dart
+++ b/example/lib/widgets/app_link.dart
@@ -17,7 +17,7 @@ class AppLink extends StatelessWidget {
   Widget build(BuildContext context) {
     return Seo.link(
       anchor: anchor,
-      href: '/flutter_seo$href', // /flutter_seo needed because of --base-href
+      href: '/flutter_seo/#$href', // /flutter_seo needed because of --base-href
       child: child,
     );
   }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,8 +6,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_web_plugins:
-    sdk: flutter
   faker: ^2.0.0
   auto_route: ^5.0.2
   seo:


### PR DESCRIPTION
Just because Github doesn't support routing all trough single path, we need to revert back to default hash url strategy so example demo doesn't return 404.

For real life scenario you can configure for example nginx to route all trough single path and use url strategy.